### PR TITLE
feat: allow multiple simultaneous dynamic imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,9 @@ Lazily loads a component defined from the callback passed to `file`.
 - `when` - the only prop with a default value of `true`, the component will load immediately when this is not used
 
 ```svelte
-<LazyLoad files={[() => import('../icons/Burger.svelte')]} let:loaded={[loaded]}>
-  <svelte:component this={loaded} />
+<!-- no when prop, indicating LazyLoad to load '../icons/Burger.svelte' immediately  -->
+<LazyLoad files={[() => import('../icons/Burger.svelte')]} let:loaded>
+  <svelte:component this={loaded[0]} />
 </LazyLoad>
 ```
 

--- a/README.md
+++ b/README.md
@@ -211,10 +211,10 @@ Image element is created to have a fixed ratio, **not size**. It will be respons
 
 ### LazyLoad
 
-| Props   | Default     |
-| ------- | ----------- |
-| file \* | `undefined` |
-| when    | `true`      |
+| Props    | Default     |
+| -------- | ----------- |
+| files \* | `undefined` |
+| when     | `true`      |
 
 Lazily loads a component defined from the callback passed to `file`.
 
@@ -224,16 +224,16 @@ Lazily loads a component defined from the callback passed to `file`.
   let show = false;
 </script>
 
-<LazyLoad file={() => import('../components/Modal.svelte')} when={show} let:loaded={Modal}>
+<LazyLoad when={show} files={[() => import('../components/Modal.svelte')]} let:loaded={[Modal]}>
   <Modal bind:show other modal props />
 </LazyLoad>
 ```
 
-- `when` - the prop with a default value of `true`, the component will load immediately when this is not used
+- `when` - the only prop with a default value of `true`, the component will load immediately when this is not used
 
 ```svelte
-<LazyLoad file={() => import('../icons/Burger.svelte')} let:loaded={BurgerIcon}>
-  <BurgerIcon />
+<LazyLoad files={[() => import('../icons/Burger.svelte')]} let:loaded={[loaded]}>
+  <svelte:component this={loaded} />
 </LazyLoad>
 ```
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,28 @@ Lazily loads a component defined from the callback passed to `file`.
 </LazyLoad>
 ```
 
+Multiple imports simultaneously
+
+```svelte
+<LazyLoad
+  when={show}
+  files={[
+    () => import('$lib/components/Modal.svelte'),
+    () => import('$lib/components/Video.svelte'),
+    () => import('$lib/components/Button.svelte'),
+    () => import('$lib/icons/Share.svelte'),
+  ]}
+  let:loaded={[Modal, Video, Button, ShareIcon]}
+>
+  <Modal bind:show>
+    <Video src="/assets/demo.mp4" />
+    <Button on:click={() => navigator.share()}>
+      <ShareIcon />
+    </Button>
+  </Modal>
+</LazyLoad>
+```
+
 ### Pagination
 
 | Props     | Default        |

--- a/src/lib/core/LazyLoad.svelte
+++ b/src/lib/core/LazyLoad.svelte
@@ -1,7 +1,9 @@
 <script>
+	/** @type {Array<() => Promise<typeof import('*.svelte')>>} */
 	export let files;
 	export let when = true;
 
+	/** @type {Promise<typeof import('*.svelte')>[] | undefined} */
 	let promises;
 	$: if (when && !promises && files.length) {
 		promises = files.map((file) => file());

--- a/src/lib/core/LazyLoad.svelte
+++ b/src/lib/core/LazyLoad.svelte
@@ -5,7 +5,7 @@
 
 	/** @type {Promise<typeof import('*.svelte')>[] | undefined} */
 	let promises;
-	$: if (when && !promises && files.length) {
+	$: if (when && !promises && Array.isArray(files)) {
 		promises = files.map((file) => file());
 	}
 </script>

--- a/src/lib/core/LazyLoad.svelte
+++ b/src/lib/core/LazyLoad.svelte
@@ -1,13 +1,15 @@
 <script>
-	export let file;
+	export let files;
 	export let when = true;
 
-	let component;
-	$: if (when && !component) component = file();
+	let promises;
+	$: if (when && !promises && files.length) {
+		promises = files.map((file) => file());
+	}
 </script>
 
-{#if component && when}
-	{#await component then { default: loaded }}
-		<slot {loaded} />
+{#if when && promises && promises.length}
+	{#await Promise.all(promises) then components}
+		<slot loaded={components.map((c) => c.default)} />
 	{/await}
 {/if}

--- a/src/lib/core/SearchBar.svelte
+++ b/src/lib/core/SearchBar.svelte
@@ -73,8 +73,8 @@
 					{#if typeof icon === 'string'}
 						<img src={icon} alt="icon" />
 					{:else}
-						<LazyLoad file={typeof icon === 'function' ? icon : icons.search} let:loaded>
-							<svelte:component this={loaded} />
+						<LazyLoad files={[typeof icon === 'function' ? icon : icons.search]} let:loaded>
+							<svelte:component this={loaded[0]} />
 						</LazyLoad>
 					{/if}
 				</span>
@@ -100,8 +100,8 @@
 
 		{#if filters}
 			<span on:click={handle.toggle('filter', !show.filter)}>
-				<LazyLoad file={icons.filter} let:loaded>
-					<svelte:component this={loaded} />
+				<LazyLoad files={[icons.filter]} let:loaded>
+					<svelte:component this={loaded[0]} />
 				</LazyLoad>
 			</span>
 		{/if}

--- a/src/lib/core/SearchBar.svelte
+++ b/src/lib/core/SearchBar.svelte
@@ -82,7 +82,7 @@
 						<img src={icon} alt="icon" />
 					{:else}
 						<LazyLoad files={[typeof icon === 'function' ? icon : icons.search]} let:loaded>
-							<svelte:component this={loaded[0]} />
+							<svelte:component this={loaded[0]} {size} />
 						</LazyLoad>
 					{/if}
 				</span>
@@ -113,7 +113,7 @@
 		{#if filters}
 			<span on:click={handle.toggle('filter', !show.filter)}>
 				<LazyLoad files={[icons.filter]} let:loaded>
-					<svelte:component this={loaded[0]} />
+					<svelte:component this={loaded[0]} {size} />
 				</LazyLoad>
 			</span>
 		{/if}


### PR DESCRIPTION
This is a breaking change for `LazyLoad` API, but would allow the component to load multiple files simultaneously, which is what we actually want when lazily loading components, especially for modal / dialog / popup components.

- `file` prop is renamed to `files` that accepts an array of import callbacks
- `let:loaded` returns the loaded components as an array with preserved order

Updated example usage is reflected in the docs

Closes #39
Resolves #49 